### PR TITLE
[OA-909] Add average latency to interval monitor

### DIFF
--- a/src/com/oltpbenchmark/ThreadBench.java
+++ b/src/com/oltpbenchmark/ThreadBench.java
@@ -271,14 +271,14 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                 long measuredLatencies = 0;
                 synchronized (testState) {
                     for (Worker w : workers) {
-                        measuredLatencies += w.getIntervalLatenciesAverage();
+                        measuredLatencies += w.getIntervalLatencies();
                         measuredRequests += w.getIntervalRequests();
                         w.resetIntervalLatencies();
                         w.resetIntervalRequests();
                     }
                 }
                 double tps = (double) measuredRequests / (double) this.intervalMonitor;
-                double latencyAve = ((double) measuredLatencies / (double) workers.size()) / 1000.0;
+                double latencyAve = ((double) measuredLatencies / (double) measuredRequests) / 1000.0;
                 LOG.info("Throughput: " + tps + " Tps");
                 LOG.info("Latency Average: " + latencyAve + " ms");
             } // WHILE

--- a/src/com/oltpbenchmark/ThreadBench.java
+++ b/src/com/oltpbenchmark/ThreadBench.java
@@ -268,13 +268,19 @@ public class ThreadBench implements Thread.UncaughtExceptionHandler {
                     return;
                 // Compute the last throughput
                 long measuredRequests = 0;
+                long measuredLatencies = 0;
                 synchronized (testState) {
                     for (Worker w : workers) {
-                        measuredRequests += w.getAndResetIntervalRequests();
+                        measuredLatencies += w.getIntervalLatenciesAverage();
+                        measuredRequests += w.getIntervalRequests();
+                        w.resetIntervalLatencies();
+                        w.resetIntervalRequests();
                     }
                 }
                 double tps = (double) measuredRequests / (double) this.intervalMonitor;
+                double latencyAve = ((double) measuredLatencies / (double) workers.size()) / 1000.0;
                 LOG.info("Throughput: " + tps + " Tps");
+                LOG.info("Latency Average: " + latencyAve + " ms");
             } // WHILE
         }
     } // CLASS

--- a/src/com/oltpbenchmark/api/Worker.java
+++ b/src/com/oltpbenchmark/api/Worker.java
@@ -148,9 +148,8 @@ public abstract class Worker implements Runnable {
         intervalRequests.set(0);
     }
 
-    public final long getIntervalLatenciesAverage() {
-        long latencyAve = intervalLatencies.get() / (long)intervalRequests.get();
-        return latencyAve;
+    public final long getIntervalLatencies() {
+        return intervalLatencies.get();
     }
 
     public final void resetIntervalLatencies() {


### PR DESCRIPTION
Provide the ability to obtain TPS and average latency for the interval monitor in oltpbench.  Users can provide the optional oltpbench interval monitor command line switch (-im <seconds>) to have the most recent TPS and average latency written to stdout at the specified time interval.
